### PR TITLE
Fix wifi-control.js example

### DIFF
--- a/views/FRE-wifi.jade
+++ b/views/FRE-wifi.jade
@@ -78,11 +78,11 @@ block content
         .large-12.columns
           .greyBar(style="height:2px;")
           
-          p Tessel's wifi can also be controlled programatically. The full API docs can be found 
-            a(href="https://tessel.io/docs/wifi") here.
+          p Tessel's wifi can also be controlled programatically. The full API docs can be found
+            a(href="https://github.com/tessel/t1-docs/blob/master/wifi.md") here.
 
           p Save the following in a file called <code>wifi-control.js</code>:
-          pre.prettyprint#exampleCode
+          pre.prettyprint#wifiExampleCode
             code.
               /* the wifi-cc3000 library is bundled in with Tessel's firmware,
                * so there's no need for an npm install. It's similar
@@ -93,15 +93,6 @@ block content
               var pass = '#####'; // put in your password here, or leave blank for unsecured
               var security = 'wpa2'; // other options are 'wep', 'wpa', or 'unsecured'
               var timeouts = 0;
-
-              function connect(){
-                wifi.connect({
-                  security: security
-                  , ssid: network
-                  , password: pass
-                  , timeout: 30 // in seconds
-                });
-              }
 
               wifi.on('connect', function(data){
                 // you're connected
@@ -149,6 +140,20 @@ block content
                     }
                     }, 20 *1000); // 20 second wait
                 })
+              }
+
+              function connect(){
+                wifi.connect({
+                security: security
+                , ssid: network
+                , password: pass
+                , timeout: 30 // in seconds
+                });
+              }
+
+              // connect wifi now, if not already connected
+              if (!wifi.isConnected()) {
+                connect();
               }
 
       .row

--- a/views/FRE-wifi.jade
+++ b/views/FRE-wifi.jade
@@ -79,7 +79,7 @@ block content
           .greyBar(style="height:2px;")
           
           p Tessel's wifi can also be controlled programatically. The full API docs can be found
-            a(href="https://github.com/tessel/t1-docs/blob/master/wifi.md") here.
+            a(href="https://github.com/tessel/t1-docs/blob/master/wifi.md")  here.
 
           p Save the following in a file called <code>wifi-control.js</code>:
           pre.prettyprint#wifiExampleCode

--- a/views/ja-FRE-wifi.jade
+++ b/views/ja-FRE-wifi.jade
@@ -80,7 +80,7 @@ block content
           
           p 無線LANをプログラムから制御することもできます。このAPIについての詳細な文書は、
 
-            a(href="https://tessel.io/docs/wifi") ここにあります。
+            a(href="https://github.com/tessel/t1-docs/blob/master/wifi.md") ここにあります。
           p 以下の内容を、<code>wifi-control.js</code>という名前のファイルに保存してください：
           pre.prettyprint#wifiExampleCode
             code.

--- a/views/ja-FRE-wifi.jade
+++ b/views/ja-FRE-wifi.jade
@@ -82,7 +82,7 @@ block content
 
             a(href="https://tessel.io/docs/wifi") ここにあります。
           p 以下の内容を、<code>wifi-control.js</code>という名前のファイルに保存してください：
-          pre.prettyprint#exampleCode
+          pre.prettyprint#wifiExampleCode
             code.
               /* wifi-cc3000というライブラリをrequireしていますが、
                * このライブラリはTesselのファームウェアに組み込まれているので、
@@ -94,15 +94,6 @@ block content
               var pass = '#####'; // パスワードを入れてください。パスワード無しの場合は、カラ文字列にしてください。
               var security = 'wpa2'; // 他に「wep」「wpa」「unsecured」が指定できます。パスワード無しの場合は「unsecured」を指定してください。
               var timeouts = 0;
-
-              function connect(){
-                wifi.connect({
-                  security: security
-                  , ssid: network
-                  , password: pass
-                  , timeout: 30 // in seconds
-                });
-              }
 
               wifi.on('connect', function(data){
                 // 無線LANに接続された
@@ -150,6 +141,19 @@ block content
                     }
                     }, 20 *1000); // 20秒待つ
                 })
+              }
+
+              function connect(){
+                wifi.connect({
+                security: security
+                , ssid: network
+                , password: pass
+                , timeout: 30 // in seconds
+                });
+              }
+
+              if (!wifi.isConnected()) {
+                connect();
               }
 
       .row


### PR DESCRIPTION
+ Now actually connects to wifi (if not already connected)
+ Fixed wifi documentation link, pointing to respective github page
+ Updated the wifi-control pre's 'id' so that it's bookmarable. It was
    sharing same id with the preceeding 'wifi' example